### PR TITLE
Fix forecast styling for dark mode

### DIFF
--- a/src/pages/MainApp.tsx
+++ b/src/pages/MainApp.tsx
@@ -340,11 +340,11 @@ export function MainApp({ userProfile, handleLogout }: MainAppProps) {
             <TableBody>
               {sortedForecast.map((entry, index) => (
                 <TableRow key={index} className={cn(
-                  entry.type === 'credit' ? 'bg-green-50' : entry.type === 'debit' ? 'bg-red-50' : '',
+                  entry.type === 'credit' ? 'bg-green-50 dark:bg-green-950/20' : entry.type === 'debit' ? 'bg-red-50 dark:bg-red-950/20' : '',
                 )}>
                   <TableCell>{format(entry.when, 'MMM dd, yyyy')}</TableCell>
                   <TableCell>{entry.summary}</TableCell>
-                  <TableCell className={entry.type === 'debit' ? 'text-red-600' : 'text-green-600'}>
+                  <TableCell className={entry.type === 'debit' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}>
                     {entry.type === 'debit' ? '-' : '+'}${entry.amount.toFixed(2)}
                   </TableCell>
                   <TableCell>${entry.balance.toFixed(2)}</TableCell>


### PR DESCRIPTION
Update forecast table row and text colors to ensure proper dark mode styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f341eae-c3dc-4b0f-83a8-c9e514289790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f341eae-c3dc-4b0f-83a8-c9e514289790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

